### PR TITLE
Feature/mkpsf simsize

### DIFF
--- a/bin/mkpsf.py
+++ b/bin/mkpsf.py
@@ -5,7 +5,7 @@
 .. code-block:: bash
 
   usage:
-    mkpsf.py [-h|--help] -a apt -w wfe -s spec -c cntl -p psf.fits
+    mkpsf.py [-h|--help] -a apt -w wfe -s spec -c cntl -n fn -p psf.fits
 
   options:
     -h --help    show this help message and exit
@@ -13,6 +13,7 @@
     -w wfe       wfe map or null
     -s spec      electrons/sec/um at lambada
     -c cntl      control parameter
+    -n fn        number of fp-cells of the output psf image.
     -p psf.fits
 """
 from docopt import docopt             # command line interface
@@ -46,9 +47,18 @@ if __name__ == '__main__':
   with open(args['-c']) as f:
     cp = json.load(f)
   M = cp['M']['val']
-  
+ 
+  # get the number of fp-cells
+  if args['-f']:
+    fN = int(args['-f'])
+  else:
+    fN = None
+
   ### psf
-  image=psf.calc_psf(wfe,wN,k,WL,NP,Ntot,Stel,adata,M,aN)
+  if fN is None:
+    image = psf.calc_psf(wfe, wN, k, WL, NP, Ntot, Stel, adata, M, aN)
+  else:
+    image = psf.calc_psf(wfe, wN, k, WL, NP, Ntot, Stel, adata, M, aN, fN)
   
   # Save 
   hdu = fits.PrimaryHDU(image)

--- a/bin/mkpsf.py
+++ b/bin/mkpsf.py
@@ -5,7 +5,7 @@
 .. code-block:: bash
 
   usage:
-    mkpsf.py [-h|--help] -a apt -w wfe -s spec -c cntl -n fn -p psf.fits
+    mkpsf.py [-h|--help] -a apt -w wfe -s spec -c cntl [-n fn] -p psf.fits
 
   options:
     -h --help    show this help message and exit
@@ -49,8 +49,8 @@ if __name__ == '__main__':
   M = cp['M']['val']
  
   # get the number of fp-cells
-  if args['-f']:
-    fN = int(args['-f'])
+  if args['-n']:
+    fN = int(args['-n'])
   else:
     fN = None
 

--- a/src/jis/photonsim/psf.py
+++ b/src/jis/photonsim/psf.py
@@ -68,9 +68,10 @@ def calc_psf(wfe, wN, k, WL, NP, Ntot, Stel, adata, M, aN, fN=520):
     # 口径 D で、計算領域の大きさを N とするとき、
     # フーリエ変換で得られる PSF は D/N x lambda/D=lambda/N の角度スケールになる。 
     # 異なるいくつかの波長 WL0, WL1, ..., WLn で生成したPSFのセルスケールを
-    # 合わせようとおもったら、計算領域を波長に比例させて
-    # N0 = M WL0 , N1 = M WL1 ,,, Nn = M WLn 
-    # と選べばよい。
+    # 合わせようとおもったら、FFT計算領域を波長に比例させて
+    # N=M WL (ここでWLはミクロン単位の波長)として設定し、
+    # 得られた結果を PSF として fN x fN のサイズで切り取って加算すればよい。
+    # なお、Mは計算する波長WLに対してNが整数になるように選んでおく。
 
     image = np.zeros( (fN, fN) ,dtype ='float' )
 

--- a/src/jis/photonsim/psf.py
+++ b/src/jis/photonsim/psf.py
@@ -3,7 +3,7 @@ import numpy as np
 import pyfftw
 from scipy.ndimage import shift
 
-def calc_psf(wfe, wN, k, WL, NP, Ntot, Stel, adata, M, aN):
+def calc_psf(wfe, wN, k, WL, NP, Ntot, Stel, adata, M, aN, fN=520):
     """
     This function calculates the psf in e-/sec/fp-cell
     based on the wavefront error (wfe),
@@ -23,9 +23,10 @@ def calc_psf(wfe, wN, k, WL, NP, Ntot, Stel, adata, M, aN):
         adata (ndarray): Aperture mask data.
         M              : Inverse number of the PSF cell scale (mm/um).
         aN    (int)    : Number of apt-cells of the aperture mask data.
+        fN    (int)    : Number of fp-cells of the output psf data (Default: 520). 
 
     Returns:
-        image (nadarray): 520 x 520 fp-cell array of the psf (e-/s/fp-cell).
+        image (nadarray): fN x fN fp-cell array of the psf (e-/s/fp-cell).
                           The fp-cell scale is (1/M) x 10^-3 rad/fp-cell.
 
     Example:
@@ -71,8 +72,7 @@ def calc_psf(wfe, wN, k, WL, NP, Ntot, Stel, adata, M, aN):
     # N0 = M WL0 , N1 = M WL1 ,,, Nn = M WLn 
     # と選べばよい。
 
-    N0    = 520
-    image = np.zeros( (N0,N0) ,dtype ='float' )
+    image = np.zeros( (fN, fN) ,dtype ='float' )
 
     # WL として、1.1, 1.2, ,,, 1.6 としているとき、
     # 1.1-1.2 の範囲のフォトンを 波長 1.15 で代表させて加え、
@@ -102,17 +102,17 @@ def calc_psf(wfe, wN, k, WL, NP, Ntot, Stel, adata, M, aN):
         fts = np.fft.fftshift(ft)
 
         # 結果を入射光子数(電子数)の重みを付けて加算する。
-        i1 = int(N/2-N0/2)
-        i2 = int(N/2+N0/2)
+        i1 = int(N/2-fN/2)
+        i2 = int(N/2+fN/2)
         NPm   = (NP[i] + NP[i+1])/2
 
         tmp_img = NPm*(fts.real[i1:i2, i1:i2]**2.+fts.imag[i1:i2, i1:i2]**2.)
         offset = 0.0
-        if   (N%2==0) and (N0%2==1):
+        if   (N%2==0) and (fN%2==1):
             offset=1.0
-        elif (N%2==0) and (N0%2==0):
+        elif (N%2==0) and (fN%2==0):
             offset=0.5
-        elif (N%2==1) and (N0%2==0):
+        elif (N%2==1) and (fN%2==0):
             offset=0.5
         tmp_img = shift(tmp_img, [-offset, -offset], order=1)
 


### PR DESCRIPTION
PSF 計算の出力ピクセルサイズを可変にする修正を行いました。
calc_psf の引数 fN にて指定できます。指定がない場合はこれまで通り 520 pix の画像で出力します。
mkpsf.py では -n 引数で指定できます。指定が無ければこれまで通り 520 pix の画像で出力します。
