### PR TITLE
addnoise.py is modified to avoid the same seed as before.

### DIFF
--- a/src/jis/pixsim/addnoise.py
+++ b/src/jis/pixsim/addnoise.py
@@ -78,6 +78,7 @@ def mk_shotnoise(data, rg=None):
 
     seed = None
     if rg is None:
+        time.sleep(0.1) # avoiding the same seed as before.
         seed = round(time.time()*10)
         rg   = np.random.Generator(np.random.PCG64(seed))
 
@@ -118,6 +119,7 @@ def mk_readnoise(shape, sigma, rg=None):
 
     seed = None
     if rg is None:
+        time.sleep(0.1) # avoiding the same seed as before.
         seed = round(time.time()*10)
         rg   = np.random.Generator(np.random.PCG64(seed))
 


### PR DESCRIPTION
addnoise.py のなかで乱数ノイズ生成部分について、
random generator (rg) の設定なしに実行した場合に
time.time 関数で seed を作り、これを使って rg を生成します。

この seed 作りに関して、現状 0.1 秒以内に同じ乱数ノイズ生成関数を使うと
同じ seed を作ってしまい、同じノイズを返してしまうことがわかりました。
これを回避するため、0.1 sec の sleep を追加しました。

@rascal352 さん、 @xr0038 さんにレビューをお願いしたく存じます。