### PR TITLE
Feature/update params 20210926a

### DIFF
--- a/params/templates/ace_002.json
+++ b/params/templates/ace_002.json
@@ -1,0 +1,9 @@
+{
+ "title":"ace001",
+ "model":"PSD = 1/f0/(1+(f/f0)^2)",
+ "note":"S0 = sqrt(PSD), S = S0 + alp * gaussian(sig=S0^bet)",
+ "f0":0.01,
+ "alp":0,
+ "bet":1,
+ "n" :0
+}

--- a/params/templates/det.json
+++ b/params/templates/det.json
@@ -1,10 +1,10 @@
 {
 "pixsize": {
   "title": "Pixel size (micron).",
-  "val"  : 15.0 },
+  "val"  : 10.0 },
 "Npix":{
   "title": "Number of pixels on a side.",
-  "val"  : 1296 },
+  "val"  : 1920 },
 "readnoise": {
   "title": "Read out noise (e-).",
   "val"  : 15 },
@@ -42,8 +42,8 @@
 "readparams": {
   "title": "Parameters related to the reset/read operation.",
   "fsmpl"     : {"val": 200e3, "title": "Sampling frequency in Hz."},
-  "ncol_ch"   : {"val": 162, "title": "Num. of col. in one ch."},
-  "nrow_ch"   : {"val":1296, "title": "Num. of row in one ch."},
+  "ncol_ch"   : {"val": 120, "title": "Num. of col. in one ch."},
+  "nrow_ch"   : {"val":1920, "title": "Num. of row in one ch."},
   "npix_pre"  : {"val":   4, "title": "Npix before reading each row."},
   "npix_post" : {"val":   4, "title": "Npix after reading each row."},
   "t_overhead": {"val": 0.1, "title": "Overhead time between reset and the 1st read in sec."}},

--- a/params/templates/src.json
+++ b/params/templates/src.json
@@ -10,10 +10,10 @@
  "val"   :3.1},
 "HwMagmax":{
   "title" :"Brightest source without saturation",
-  "val" : 9.5},
+  "val" : 9.7},
 "HwMag" : {
  "title": "Hw magnitude of the source",
- "val" : 12.5},
+ "val" : 12.7},
 "DiffuseJ" :{
  "title": "Diffuse photons/sec/m2/arcsec2 at J",
  "val" : 0},

--- a/params/templates/tel.json
+++ b/params/templates/tel.json
@@ -12,8 +12,8 @@
 "Eopt":{
   "title": "Spectral efficiency of the optics with filters.",
   "wavelength": {"val": [1.1, 1.6], "title": "Wavelengths in micron."},
-  "efficiency": {"val": [0.88, 0.88], "title": "Efficiencies."}},
+  "efficiency": {"val": [0.77, 0.77], "title": "Efficiencies."}},
 "EFL":{
  "title": "Effective focal length (mm)",
- "val": 7300.0}
+ "val": 4860.0}
 }


### PR DESCRIPTION
最近のパラメータ更新にともない、パラメータのテンプレートファイルを修正しました。
主な修正内容は下記のとおりです。
- ピクセルサイズ変更 (15->10 um)
- ピクセル数変更 (1290 -> 1920 pix)
- チャンネル当たりの読み出し領域幅変更 (162 -> 120 pix; 読み出し ch 数の変更も加味)
- 観測天体の等級設定
- 光学系効率修正 (0.88->0.77)
- 有効焦点距離変更 (7300 -> 4860 mm)
- PS 擾乱の無い単純な ACE モデルパラメータ追加 (ace_002.json)