### PR TITLE
Feature/gauss ace20211204

### DIFF
--- a/bin/mkimage.py
+++ b/bin/mkimage.py
@@ -187,7 +187,7 @@ if __name__ == '__main__':
     # Ace simulation. ##############################################
     nace = control_params.ace_control.get('nace')
     tace = control_params.ace_control.get('tace')
-    if control_params.effect.ace is True:
+    if control_params.effect.ace == "real":
         print("Making ACE (X)...")
         rg_acex = np.random.default_rng(control_params.ace_control.get('acex_seed'))
         acex, psdx = calc_ace(rg_acex, nace, tace, ace_params)
@@ -197,7 +197,7 @@ if __name__ == '__main__':
         rg_acey = np.random.default_rng(control_params.ace_control.get('acey_seed'))
         acey, psdy = calc_ace(rg_acey, nace, tace, ace_params)
         # the standard deviation of acey is normalized to unity.
-    else:
+    else: # dummy/gauss mode
         print("ACE simulation is skipped.")
         print("Generate fake ACE(X) and ACE(Y)...")
         acex = calc_dummy_ace(np.random, nace, tace, ace_params)

--- a/bin/mkimage.py
+++ b/bin/mkimage.py
@@ -258,6 +258,14 @@ if __name__ == '__main__':
     fp_scale = fp_cellsize_rad * 3600.*180./np.pi           # arcsec/fp-cell.
     psfscale = fp_scale/detpix_scale                        # det-pix/fp-cell.
 
+    ## In the gauss-ace mode, apply gauss filter to psf, here.
+    if control_params.effect.ace == "gauss":
+        if acex_std != acey_std:
+            print("In the current gauss-ace mode, acex_std must be equal to acey_std. Sorry!")
+            exit(-1)
+        else:
+            psf = ndimage.gaussian_filter(psf, sigma=acex_std/fp_scale)
+
 
     # Making image. ################################################
     uniform_flat_interpix = np.ones_like(detector.flat.interpix)
@@ -338,12 +346,6 @@ if __name__ == '__main__':
                 # But, in dummy/gauss mode, the scaling is not correct for simulating a single-shot image.
                 # Therefore, we divide pixar by Nts_per_plate for correction.
 
-                if control_params.effect.ace == "gauss":
-                    if acex_std != acey_std:
-                        print("In the current gauss-ace mode, acex_std must be equal to acey_std. Sorry!")
-                        exit(-1)
-                    else:
-                        pixar = ndimage.gaussian_filter(pixar, sigma=acex_std/detpix_scale)
 
             # magnitude scaling.
             pixar = pixar * 10.**(mag/(-2.5))

--- a/bin/mkimage.py
+++ b/bin/mkimage.py
@@ -335,7 +335,7 @@ if __name__ == '__main__':
                 pixar=pixar/Nts_per_plate
                 # In the above process to make pixar, Nts_per_plate is multiplied
                 # to the result of simpix to make the units of pixar to be e/pix/dtace.
-                # But, in dummy/gauss mode, the scaling is not correct for simulating a single-shot image. 
+                # But, in dummy/gauss mode, the scaling is not correct for simulating a single-shot image.
                 # Therefore, we divide pixar by Nts_per_plate for correction.
 
                 if control_params.effect.ace == "gauss":

--- a/params/templates/ctl.json
+++ b/params/templates/ctl.json
@@ -8,8 +8,8 @@
     "title": "simulate a physically realistic point spread function",
     "val": true },
   "ace": {
-    "title": "incorporate the attitude control error",
-    "val": true },
+    "title": "incorporate the attitude control error (dummy/gauss/real)",
+    "val": "dummy" },
   "flat_interpix": {
     "title": "incorporate the interpix flat non-uniformity",
     "val": true },
@@ -58,16 +58,16 @@
     "title": "Time range of ACE simulation in sec (to be adjusted).",
     "val": 360},
   "acex_std": {
-    "title": "standard deviation of ACE along with X-axis (arcsec).",
+    "title": "standard deviation of ACE along with X-axis (arcsec; gauss/real mode).",
     "val": 0.276},
   "acey_std": {
-    "title": "standard deviation of ACE along with Y-axis (arcsec).",
+    "title": "standard deviation of ACE along with Y-axis (arcsec; gauss/real mode).",
     "val": 0.276},
   "acex_seed": {
-    "title": "random number seed for ACE along with X axis.",
+    "title": "random number seed for ACE along with X axis (for real mode).",
     "val": 1},
   "acey_seed": {
-    "title": "random number seed for ACE along with Y axis.",
+    "title": "random number seed for ACE along with Y axis (for real mode).",
     "val": 2}},
 "Nplate": {
   "title": "Number of plates which make up a small frame.",


### PR DESCRIPTION
gaussian convolution で ace を考慮するモードの実装です。

下記のように実装しました。
- ace 計算モードを dummy/gauss/real としました。
-- dummy が従来の no-ace mode
-- gauss が新たに実装する gaussian convolution で ace を考慮するモード
-- real が従来の ace mode
- gaussian convolution は昔の bin/convolve.py にあったのと同様に ndimage.gauss_filter 関数を使用することにしました。

前回と同様に関連しそうな @xr0038 @HajimeKawahara @kataza さんに review をお願いしたいと思います。
何卒よろしくお願いいたします。