### PR TITLE
Bugfix on mkimage.py (TK).

### DIFF
--- a/bin/mkimage.py
+++ b/bin/mkimage.py
@@ -443,7 +443,7 @@ if __name__ == '__main__':
     hdu.header["COBS"]    = telescope.cobs
     hdu.header["STYPE"]   = telescope.spider.type
     hdu.header["STEL"]    = telescope.total_area  # total area in m^2
-    hdu.list = pf.HDUList([hdu])
+    hdulist = pf.HDUList([hdu])
     hdulist.writeto(filename_aperture, overwrite=overwrite)
 
     hdu = pf.PrimaryHDU(acex)


### PR DESCRIPTION
@kataza さんのご指摘を受けての 446 行目のバグ修正。
これまでは aperture のファイルとして wfe のデータが書き込まれていた。
これを正しく aperture の画像が出力されるように修正。

review をお願いできますと幸いです @kataza 