### PR TITLE
use `RectBivariateSpline` instead of `interp2d`

### DIFF
--- a/src/jis/photonsim/wfe.py
+++ b/src/jis/photonsim/wfe.py
@@ -7,6 +7,7 @@ from jis.photonsim import zernike                       # Zernike polynomials fu
 import json
 import pandas as pd
 from scipy.interpolate import RectBivariateSpline
+from functools import cmp_to_key
 
 def calc_wfe(EPD,efile):
     """
@@ -257,9 +258,14 @@ def read_FringeZernike37(filename, scale):
     # RectBivariateSpline requires regular grid points.
     # The index `idx` is used to rearrange the Zernike coefficients
     # to make the functions compatible with the `interp2d` results.
+    # The elements are arranged in the following order:
+    #   (x1,y1), (x1,y2), ..., (x1,yn), (x2,y1), (x2,y2), ..., (xn,yn)
     xtic = np.sort(np.unique(xan))
     ytic = np.sort(np.unique(yan))
-    idx = np.argsort(1e3*xan+yan)
+    xyn = [(xy,n) for n,xy in enumerate(np.vstack([xan,yan]).T)]
+    key = cmp_to_key(
+        lambda x,y: x[0][1]-y[0][1] if x[0][0]==y[0][0] else x[0][0]-y[0][0])
+    idx = np.array([z[1] for z in sorted(xyn, key=key)])
     ny,nx = ytic.size,xtic.size
 
     # Making and storing interpolation functions.

--- a/src/jis/photonsim/wfe.py
+++ b/src/jis/photonsim/wfe.py
@@ -265,7 +265,7 @@ def read_FringeZernike37(filename, scale):
     # Making and storing interpolation functions.
     functions = {}
     for i in range(1,38):
-        zarr = np.array(df[str(i)])[idx].reshape((ny,nx)) * scale
+        zarr = np.array(df[str(i)])[idx].reshape((nx,ny)) * scale
         functions[i] = RectBivariateSpline(xtic, ytic, zarr, kx=1, ky=1)
 
     return functions

--- a/src/jis/photonsim/wfe.py
+++ b/src/jis/photonsim/wfe.py
@@ -251,12 +251,15 @@ def read_FringeZernike37(filename, scale):
     # Loading data.
     df = pd.read_csv(filename, index_col=0, header=None).T
 
-    # Grid data.
+    # Load grid data.
     xan = np.array(df['xan'])
     yan = np.array(df['yan'])
-    idx = np.argsort(xan+yan*1e3)
+    # RectBivariateSpline requires regular grid points.
+    # The index `idx` is used to rearrange the Zernike coefficients
+    # to the standard Python array order.
     xtic = np.sort(np.unique(xan))
     ytic = np.sort(np.unique(yan))
+    idx = np.argsort(xan+yan*1e3)
     ny,nx = ytic.size,xtic.size
 
     # Making and storing interpolation functions.

--- a/src/jis/photonsim/wfe.py
+++ b/src/jis/photonsim/wfe.py
@@ -256,10 +256,10 @@ def read_FringeZernike37(filename, scale):
     yan = np.array(df['yan'])
     # RectBivariateSpline requires regular grid points.
     # The index `idx` is used to rearrange the Zernike coefficients
-    # to the standard Python array order.
+    # to make the functions compatible with the `interp2d` results.
     xtic = np.sort(np.unique(xan))
     ytic = np.sort(np.unique(yan))
-    idx = np.argsort(xan+yan*1e3)
+    idx = np.argsort(1e3*xan+yan)
     ny,nx = ytic.size,xtic.size
 
     # Making and storing interpolation functions.


### PR DESCRIPTION
`photonsim/wfe.py` の `read_FringeZernike37` の内挿方法を変更しました．

`scipy.interpolate.interp2d` では `kind='linear'` で補間すると artificial なパターンが生まれてしまうケースがいくつかありました．`interp2d` の内部で使用されているコードに問題があるようです．`scipy.interpolate.RectBivaliateSpline` を使用することできれいに補間できることがわかったのでコードを変更しました．