### PR TITLE
fix .gitignore file to add .github/actions/build

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,7 @@
+runs:
+  using: "Composite"
+  steps:
+    - name: Build Package
+      run: |
+        python setup.py install
+      shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,5 +15,8 @@ jobs:
       with:
         python-version: 3.9
 
+    - name: get dependencies
+      uses: ./.github/actions/get_dependencies
+
     - name: build
       uses: ./.github/actions/build

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 __pycache__/
-build/
-dist/
-*.egg-info/
+/build/
+/dist/
+/*.egg-info/


### PR DESCRIPTION
`.gitignore` のせいで `.github/actions/build` ディレクトリが無視されていたのを修正します．