### PR TITLE
Bugfix/random wfe filenames arg20221018

### DIFF
--- a/bin/mkimage.py
+++ b/bin/mkimage.py
@@ -69,7 +69,7 @@ if __name__ == '__main__':
         control_params, telescope, detector)
 
     # Running calculations. ########################################
-    wfe = run_calc_wfe(control_params, telescope)
+    wfe = run_calc_wfe(control_params, telescope, filenames)
     psf = run_calc_psf(control_params, telescope, detector, wfe)
     acex, acey, Nts_per_plate = run_calc_ace(control_params, detector, ace_params)
         # acex and acey are normalized with their stddevs.

--- a/src/jis/binutils/runphotonsim.py
+++ b/src/jis/binutils/runphotonsim.py
@@ -7,7 +7,7 @@ from jis.photonsim.response import calc_response
 from jis.photonsim.ace import calc_ace, calc_dummy_ace
 
 
-def run_calc_wfe(control_params, telescope):
+def run_calc_wfe(control_params, telescope, filenames):
     """Making wfe.
 
     Args:


### PR DESCRIPTION
run_calc_wfe の軽微なバグ修正です。
random mode の時に filenames が必要となるところ
filenames が undefined になる状態でした。
run_calc_wfe の引数に filenames を取るようにして解決しました。