### PR TITLE
Feature/update20230329

### DIFF
--- a/params/templates/ctl.json
+++ b/params/templates/ctl.json
@@ -87,7 +87,7 @@
   "val": 3.1},
 "J-H": {
   "title": "Color excess E(J-h).",
-  "val": 3.0},
+  "val": 1.0},
 "alpha": {
   "title": "Interpolation factor",
   "val": 0.75}

--- a/params/templates/ctl.json
+++ b/params/templates/ctl.json
@@ -87,7 +87,7 @@
   "val": 3.1},
 "J-H": {
   "title": "Color excess E(J-h).",
-  "val": 2.0},
+  "val": 3.0},
 "alpha": {
   "title": "Interpolation factor",
   "val": 0.75}

--- a/params/templates/ctl.json
+++ b/params/templates/ctl.json
@@ -66,10 +66,10 @@
     "val": 360},
   "acex_std": {
     "title": "standard deviation of ACE along with X-axis (arcsec; gauss/real mode).",
-    "val": 0.276},
+    "val": 0.275},
   "acey_std": {
     "title": "standard deviation of ACE along with Y-axis (arcsec; gauss/real mode).",
-    "val": 0.276},
+    "val": 0.275},
   "acex_seed": {
     "title": "random number seed for ACE along with X axis (for real mode).",
     "val": 1},

--- a/params/templates/ctl.json
+++ b/params/templates/ctl.json
@@ -19,10 +19,7 @@
 
 "M": {
  "title"  :"Cell scale is 1/M [um/mm] ",
- "val"   :6320},
-"CellPix": {
- "title"  :"Number of cells corresponds to detector pixel size",
- "val"   : 13 },
+ "val"   :5700},
 "fN": {
  "title"  :"Number of fp-cells of the psf data calculated by calc_psf",
  "val"   : 520},

--- a/params/templates/det.json
+++ b/params/templates/det.json
@@ -44,8 +44,8 @@
   "fsmpl"     : {"val": 200e3, "title": "Sampling frequency in Hz."},
   "ncol_ch"   : {"val": 123, "title": "Num. of col. in one ch."},
   "nrow_ch"   : {"val":1968, "title": "Num. of row in one ch."},
-  "npix_pre"  : {"val":   4, "title": "Npix before reading each row."},
-  "npix_post" : {"val":   4, "title": "Npix after reading each row."},
+  "npix_pre"  : {"val":   0, "title": "Npix before reading each row."},
+  "npix_post" : {"val":   0, "title": "Npix after reading each row."},
   "t_overhead": {"val": 0.1, "title": "Overhead time between reset and the 1st read in sec."}},
 "gain": {
   "title": "Conversion gain in e/adu.",

--- a/params/templates/det.json
+++ b/params/templates/det.json
@@ -13,7 +13,7 @@
   "val"  :  25. },
 "Fullwell": {
   "title": "Full well (e-).",
-  "val"  : 100000},
+  "val"  : 150000},
 "QE": {
   "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
   "wavelength": {"val": [0.9, 1.4, 1.6], "title": "Wavelength in micron."},

--- a/params/templates/det.json
+++ b/params/templates/det.json
@@ -10,7 +10,7 @@
   "val"  : 15 },
 "Idark":{
   "title": "Dark current w stray light (e-/sec/pix).",
-  "val"  :  39.0 },
+  "val"  :  31.0 },
 "Fullwell": {
   "title": "Full well (e-).",
   "val"  : 150000},

--- a/params/templates/det.json
+++ b/params/templates/det.json
@@ -10,7 +10,7 @@
   "val"  : 15 },
 "Idark":{
   "title": "Dark current w stray light (e-/sec/pix).",
-  "val"  :  25. },
+  "val"  :  39. },
 "Fullwell": {
   "title": "Full well (e-).",
   "val"  : 150000},

--- a/params/templates/det.json
+++ b/params/templates/det.json
@@ -49,7 +49,7 @@
   "t_overhead": {"val": 0.1, "title": "Overhead time between reset and the 1st read in sec."}},
 "gain": {
   "title": "Conversion gain in e/adu.",
-  "val": 3},
+  "val": 3.3},
 "location": {
   "title": "Parameters defining the detector location on the telescope focal plane.",
   "offset_x": {"val": 1.65, "title": "Offset in x direction in mm."},

--- a/params/templates/det.json
+++ b/params/templates/det.json
@@ -16,8 +16,8 @@
   "val"  : 150000},
 "QE": {
   "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
-  "wavelength": {"val": [0.9, 1.4, 1.6], "title": "Wavelength in micron."},
-  "qe_value": {"val": [0.83, 0.76, 0.71], "title": "QE values." }},
+  "wavelength": {"val": [0.851, 0.898, 0.945, 1.04, 1.13, 1.23, 1.32, 1.42, 1.51, 1.55, 1.61], "title": "Wavelength in micron."},
+  "qe_value": {"val": [0.69, 0.83, 0.83, 0.80, 0.81, 0.81, 0.78, 0.76, 0.73, 0.71, 0.0], "title": "QE values." }},
 "spixdim": {
   "title": "Dimensions of the subpixel grid.",
   "val": [32, 32]},

--- a/params/templates/det.json
+++ b/params/templates/det.json
@@ -10,7 +10,7 @@
   "val"  : 15 },
 "Idark":{
   "title": "Dark current w stray light (e-/sec/pix).",
-  "val"  :  39. },
+  "val"  :  39.0 },
 "Fullwell": {
   "title": "Full well (e-).",
   "val"  : 150000},

--- a/params/templates/tel.json
+++ b/params/templates/tel.json
@@ -11,8 +11,8 @@
   "thickness": {"val": 5, "title": "Spider thickness in mm."}},
 "Eopt":{
   "title": "Spectral efficiency of the optics with filters.",
-  "wavelength": {"val": [1.0, 1.6], "title": "Wavelengths in micron."},
-  "efficiency": {"val": [0.77, 0.77], "title": "Efficiencies."}},
+  "wavelength": {"val": [0.85, 1.0, 1.2, 1.4, 1.8], "title": "Wavelengths in micron."},
+  "efficiency": {"val": [0.74, 0.79, 0.82, 0.84, 0.85], "title": "Efficiencies."}},
 "EFL":{
  "title": "Effective focal length (mm)",
  "val": 4370.4}

--- a/params/templates/tel.json
+++ b/params/templates/tel.json
@@ -11,8 +11,8 @@
   "thickness": {"val": 5, "title": "Spider thickness in mm."}},
 "Eopt":{
   "title": "Spectral efficiency of the optics with filters.",
-  "wavelength": {"val": [0.85, 0.99, 1.00, 1.2, 1.4, 1.8], "title": "Wavelengths in micron."},
-  "efficiency": {"val": [0.0, 0.0, 0.789, 0.818, 0.837, 0.847], "title": "Efficiencies."}},
+  "wavelength": {"val": [0.85, 0.99165, 1.0, 1.00835, 1.2, 1.4, 1.8], "title": "Wavelengths in micron."},
+  "efficiency": {"val": [0.0, 0.0, 0.393815, 0.78887874, 0.81754, 0.83748, 0.84745], "title": "Efficiencies."}},
 "EFL":{
  "title": "Effective focal length (mm)",
  "val": 4370.4}

--- a/params/templates/tel.json
+++ b/params/templates/tel.json
@@ -15,5 +15,5 @@
   "efficiency": {"val": [0.77, 0.77], "title": "Efficiencies."}},
 "EFL":{
  "title": "Effective focal length (mm)",
- "val": 4370.4}
+ "val": 4384.6}
 }

--- a/params/templates/tel.json
+++ b/params/templates/tel.json
@@ -11,8 +11,8 @@
   "thickness": {"val": 5, "title": "Spider thickness in mm."}},
 "Eopt":{
   "title": "Spectral efficiency of the optics with filters.",
-  "wavelength": {"val": [0.85, 1.0, 1.2, 1.4, 1.8], "title": "Wavelengths in micron."},
-  "efficiency": {"val": [0.74, 0.79, 0.82, 0.84, 0.85], "title": "Efficiencies."}},
+  "wavelength": {"val": [0.85, 0.99, 1.00, 1.2, 1.4, 1.8], "title": "Wavelengths in micron."},
+  "efficiency": {"val": [0.0, 0.0, 0.789, 0.818, 0.837, 0.847], "title": "Efficiencies."}},
 "EFL":{
  "title": "Effective focal length (mm)",
  "val": 4370.4}

--- a/src/jis/photonsim/psf.py
+++ b/src/jis/photonsim/psf.py
@@ -63,14 +63,15 @@ def calc_psf(wfe, wN, WL, NP, Ntot, Stel, adata, M, aN, fN=520):
     wfer = np.nan_to_num( wfe )
     wfec = np.empty( (wN,wN),dtype='complex128')
 
-    # We define the wavelength grid with k points.
-    # When the aperture diameter is D, and the size of the calculation region is N,
-    # the PSF image obtained through FFT will have an angle grid scale of
+    # We define the wavelength grid with k points. When the aperture diameter
+    # is D, and the size of the calculation region is N, the PSF image
+    # obtained through FFT will have an angle grid scale of
     # D/N x lambda/D=lambda/N. To equalize the PSF angle scales for different
     # wavelengths, WL0, WL1, ..., WLn, it is a good way to vary the calculation
     # region N in prop. to wavelength as, N=M WL (WL: wavelength in um) and
     # add the obtained PSF images after extracting the central fN x fN region.
-    # For accuracy, M should be chosen such that N is an integer for all wavelengths.
+    # For accuracy, M should be chosen such that N is an integer
+    # for all wavelengths.
 
     image = np.zeros( (fN, fN) ,dtype ='float' )
 
@@ -119,7 +120,8 @@ def calc_psf(wfe, wN, WL, NP, Ntot, Stel, adata, M, aN, fN=520):
 
         image = image + tmp_img
 
-    # Normalizing the resutl such that the total value equals to the electron rate.
+    # Normalizing the resutl such that the total value
+    # equals to the electron rate.
     s     = np.sum(image)
     image = image/s * Ntot * Stel
 

--- a/src/jis/photonsim/response.py
+++ b/src/jis/photonsim/response.py
@@ -73,14 +73,9 @@ def calc_response(control_params, telescope, detector):
     m_scale  = H_abs + (coeff1*JH + coeff2*JH**2 + Ah)
 
     # Array for wavelength
-    # WL[i] should be in (WLshort,WLlong and 0.1 um step)
-    Wlist=[]
+    # WL[i] should be in (WLshort,WLlong and 0.01 um step)
     eps = 1e-8
-    for i in range(22):
-        w = i/10+0.4  # from 0.4 um to 2.5 um
-        if w >= WLshort-eps and w <= WLlong+eps :
-            Wlist.append(w)
-    WL = np.array(Wlist)
+    WL = np.arange(0.4, 2.51, 0.01) # from 0.4 to 2.5 um.
 
     # interpolate efficiency and qe
     EPinter = interpolate.interp1d(WLdefined, EPdefined, kind='linear',

--- a/src/jis/photonsim/response.py
+++ b/src/jis/photonsim/response.py
@@ -66,11 +66,15 @@ def calc_response(control_params, telescope, detector):
     QEdet = detector.qe.val
 
     _, J_abs, H_abs = absmags(t_eff)
-    coeff1  = 0.9
-    coeff2  = -0.06
+    #coeff1  = 0.9
+    #coeff2  = -0.06
+    coeff1  = 1.08
+    coeff2  = -0.15
+    coeff3  = 0.010
 
     Ah  = Awl_n20(JH, J_abs, H_abs, WL_H)
-    m_scale  = H_abs + (coeff1*JH + coeff2*JH**2 + Ah)
+    #m_scale  = H_abs + (coeff1*JH + coeff2*JH**2 + Ah)
+    m_scale  = H_abs + (coeff1*JH + coeff2*JH**2 + coeff3*JH**3 + Ah)
 
     # Array for wavelength
     # WL[i] should be in (WLshort,WLlong and 0.1 um step)

--- a/src/jis/photonsim/response.py
+++ b/src/jis/photonsim/response.py
@@ -38,7 +38,7 @@ def calc_response(control_params, telescope, detector):
     Hw magnitude is assumed to be zero and to have the relation with the
     J- and H-band magnitudes used in the telescope_baseline repository
     described as follows,
-      Hw - H = 0.9*(J - H) - 0.06*(J - H)^2,
+      Hw - H = 1.08*(J - H) - 0.15*(J - H)^2 + 0.01*(J - H)^3
     where J, H, and Hw are the J-, H-, and Hw-band magnitudes
     in the Vega system (See also JASMINE-CZ-TN-TY-220914Hw関係式.pdf).
 

--- a/src/jis/photonsim/response.py
+++ b/src/jis/photonsim/response.py
@@ -66,14 +66,11 @@ def calc_response(control_params, telescope, detector):
     QEdet = detector.qe.val
 
     _, J_abs, H_abs = absmags(t_eff)
-    #coeff1  = 0.9
-    #coeff2  = -0.06
     coeff1  = 1.08
     coeff2  = -0.15
     coeff3  = 0.010
 
     Ah  = Awl_n20(JH, J_abs, H_abs, WL_H)
-    #m_scale  = H_abs + (coeff1*JH + coeff2*JH**2 + Ah)
     m_scale  = H_abs + (coeff1*JH + coeff2*JH**2 + coeff3*JH**3 + Ah)
 
     # Array for wavelength

--- a/src/jis/photonsim/response.py
+++ b/src/jis/photonsim/response.py
@@ -25,7 +25,7 @@ def fluxdensity_spline(t_eff):
     nphoton     = flux * wav * 1.0e-6 /h/c
     logL        = np.log10(wav)
     logN        = np.log10(nphoton)
-    Npspline    = interpolate.interp1d(logL,logN,kind="cubic")
+    Npspline    = interpolate.interp1d(logL,logN,kind="cubic",bounds_error=False, fill_value=-np.inf)
 
     return Npspline
 

--- a/src/jis/photonsim/response.py
+++ b/src/jis/photonsim/response.py
@@ -25,7 +25,8 @@ def fluxdensity_spline(t_eff):
     nphoton     = flux * wav * 1.0e-6 /h/c
     logL        = np.log10(wav)
     logN        = np.log10(nphoton)
-    Npspline    = interpolate.interp1d(logL,logN,kind="cubic",bounds_error=False, fill_value=-np.inf)
+    Npspline    = interpolate.interp1d(logL,logN,kind="cubic",
+                    bounds_error=False, fill_value=-np.inf)
 
     return Npspline
 
@@ -86,7 +87,7 @@ def calc_response(control_params, telescope, detector):
     QE = QEinter(WL)
 
     # Removing data in non-sensitive wavelength region.
-    pos = np.where(EP*QE>0.)
+    pos = np.where(EP*QE > 0.)
     i_min = np.min(pos[0])-1
     i_max = np.max(pos[0])+1
     WL = np.array(WL[i_min:i_max+1])

--- a/src/jis/photonsim/response.py
+++ b/src/jis/photonsim/response.py
@@ -85,6 +85,14 @@ def calc_response(control_params, telescope, detector):
     EP = EPinter(WL)
     QE = QEinter(WL)
 
+    # Removing data in non-sensitive wavelength region.
+    pos = np.where(EP*QE>0.)
+    i_min = np.min(pos[0])-1
+    i_max = np.max(pos[0])+1
+    WL = np.array(WL[i_min:i_max+1])
+    EP = np.array(EP[i_min:i_max+1])
+    QE = np.array(QE[i_min:i_max+1])
+
     # photon flux of a dwarf star at 10 pc (ph/s/m^2/um).
     Np=Nphotons(WL, t_eff)
 


### PR DESCRIPTION
試験に向けていろいろとアップデートしました。ごちゃ混ぜになりすみません。

主な変更内容は下記の通りです。
- 波長グリッドを 0.1 um から 0.01 um に変更しました
  - 関連して M パラメータを 6320 から 5700 に変更
  - 関連して EFL は 4384.6 (CellPix を 13 に近づけるべく)
  - 感度のない波長域のグリッドを削除するように変更
- 使わなくなっている CellPix パラメータの欄を削除
- psf.py の日本語コメントを英語に修正
- デフォルトパラメータを修正
  - ace の stddev を 0.275 arcsec に変更
  - J-H は 1.0 に変更
  - Dark current の値を 31 e/s/pix に変更 (no bg light)
  - FullWell は 150000 e に変更
  - QE を現行ベースラインの通りに変更
  - npix_pre/post を 0 に変更
  - conv. gain を 3.3 e/adu に変更
  - 光学スループットを現行ベースラインの通りに変更
- interpolation 関数について、範囲外の対応を実装
  - response.py の Nspline, EPinter, QEinter

 @koheimiyakawajp さんには response.py まわりを、 @kataza さんには psf.py まわりを、 @yanotaihei さんにはパラメータ関係をご確認いただけますと幸いです。