### PR TITLE
Feature/output psf wcs20230615

### DIFF
--- a/src/jis/binutils/save.py
+++ b/src/jis/binutils/save.py
@@ -23,13 +23,16 @@ def save_outputs(filenames, output_format, control_params, telescope, detector, 
                    uniform_flat_intrapix, overwrite=overwrite)
 
     # psf
+    def calc_center(data, axis):
+        return data.shape[axis] * 0.5 + 0.5
+
     hdu = pf.PrimaryHDU(psf)
     detpix_scale, fp_cellsize_rad, fp_scale, psfscale = get_pixelscales(
         control_params, telescope, detector)
     hdu.header['CRVAL1'] = 0.0
     hdu.header['CRVAL2'] = 0.0
-    hdu.header['CRPIX1'] = psf.shape[1]*0.5+0.5
-    hdu.header['CRPIX2'] = psf.shape[0]*0.5+0.5
+    hdu.header['CRPIX1'] = calc_center(psf, 1)
+    hdu.header['CRPIX2'] = calc_center(psf, 0)
     hdu.header['CDELT1'] = fp_scale
     hdu.header['CDELT2'] = fp_scale
     hdu.header['CUNIT1'] = 'arcsec'


### PR DESCRIPTION
This PR aims at improving the header of the output PSF file. The header will include CRVAL, CRPIX, CDELT, and CUNIT. These are useful for checking the validity of the PSF calculations.