### PR TITLE
Detector configuration files for InP layers of different thicknesses

### DIFF
--- a/params/InP/det_InP01.json
+++ b/params/InP/det_InP01.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.01640025473953754,
+    0.04291865146357788,
+    0.07119786973009438,
+    0.10142884199550044,
+    0.1338237154335881,
+    0.16861585193552894,
+    0.2,
+    0.20456078212043993,
+    0.23490313165208682,
+    0.2677753362312072,
+    0.3035115276565238,
+    0.3425094818788975,
+    0.35,
+    0.36877269169347077,
+    0.3938230299748682,
+    0.4215124790982421,
+    0.43,
+    0.4439211370613305,
+    0.465406342087148,
+    0.48,
+    0.5202381526712893,
+    0.6353131441514588,
+    0.69,
+    0.7924365601717274,
+    0.83,
+    0.83,
+    0.8273474560492153,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP05.json
+++ b/params/InP/det_InP05.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    1.9192415891274932e-07,
+    3.648472658845314e-06,
+    2.6752070185084402e-05,
+    0.00012040418746395608,
+    0.0003989122211841509,
+    0.0010662827100319048,
+    0.002137081732837959,
+    0.0024130214515211447,
+    0.004486731334903207,
+    0.00785752940673604,
+    0.013159899462326095,
+    0.02118311866223627,
+    0.02301323026945091,
+    0.031199466573997376,
+    0.04369130447116799,
+    0.06042795292624691,
+    0.06642405559664448,
+    0.08341948993767508,
+    0.10969276925993855,
+    0.12595145760965473,
+    0.14535825478992914,
+    0.28056860782043525,
+    0.39069199608678296,
+    0.6132593648026278,
+    0.7203056158422284,
+    0.8292108370384756,
+    0.826697894122158,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP10.json
+++ b/params/InP/det_InP10.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    1.3136463433598449e-13,
+    2.9781212918779654e-11,
+    1.3994919014234086e-09,
+    2.6530274670282157e-08,
+    2.778482492797329e-07,
+    1.9014715179861446e-06,
+    7.341926841234157e-06,
+    9.380688003877036e-06,
+    3.1858963138686744e-05,
+    9.542898776535078e-05,
+    0.0002603750086436525,
+    0.0006533359022618389,
+    0.0007662394471633754,
+    0.0014235826562942098,
+    0.0027974503624772777,
+    0.00533055205981,
+    0.006432748237326005,
+    0.010320949720832326,
+    0.018013998824108087,
+    0.023654057515165375,
+    0.02952817299717122,
+    0.10100738387234531,
+    0.191896164047961,
+    0.4451371027043704,
+    0.6033442611949138,
+    0.8282254384117654,
+    0.8258866588258537,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP15.json
+++ b/params/InP/det_InP15.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    8.991399129732296e-20,
+    2.430936794232101e-16,
+    7.321218764003276e-14,
+    5.845772384713116e-12,
+    1.9352540616241242e-10,
+    3.3908398773570555e-09,
+    2.5223129707094666e-08,
+    3.646768551129541e-08,
+    2.262211522175083e-07,
+    1.1589764714227539e-06,
+    5.151646129232588e-06,
+    2.015037577754051e-05,
+    2.5512406711917182e-05,
+    6.495584065500354e-05,
+    0.00017911409662049537,
+    0.0004702258455954193,
+    0.0006229708426130981,
+    0.0012769438319454405,
+    0.00295830031299503,
+    0.004442302197603648,
+    0.005998372791493372,
+    0.03636362484025637,
+    0.09425362726945233,
+    0.32310479313726115,
+    0.5053747874660054,
+    0.8272412107905585,
+    0.8250762195914612,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP20.json
+++ b/params/InP/det_InP20.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    6.154263567116321e-26,
+    1.9842891267282867e-21,
+    3.829978875610285e-18,
+    1.2880776847799962e-15,
+    1.3479330147810447e-13,
+    6.046787956125763e-12,
+    8.665385613049463e-11,
+    1.4176914166648556e-10,
+    1.6063300455774497e-09,
+    1.4075664981529364e-08,
+    1.0192782317737255e-07,
+    6.214837460644584e-07,
+    8.494510412428525e-07,
+    2.9638329861235795e-06,
+    1.1468249817225018e-05,
+    4.148019630706103e-05,
+    6.033077254511013e-05,
+    0.00015798793658031764,
+    0.0004858188804894515,
+    0.0008342775357750793,
+    0.001218513456595329,
+    0.013091252944379487,
+    0.0462945483956027,
+    0.234527085506969,
+    0.4233133423702203,
+    0.8262581527832819,
+    0.8242665756378079,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP25.json
+++ b/params/InP/det_InP25.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    4.2123544408447025e-32,
+    1.619706175740319e-26,
+    2.003592388161352e-22,
+    2.838194874584789e-19,
+    9.388552378553777e-17,
+    1.0783064346537831e-14,
+    2.976986150997908e-13,
+    5.511314811198165e-13,
+    1.1406078476887632e-11,
+    1.7094768492498805e-10,
+    2.016691534522252e-09,
+    1.91679823188615e-08,
+    2.8282987160576772e-08,
+    1.3523504400920334e-07,
+    7.342847735147626e-07,
+    3.6591070052595975e-06,
+    5.842652443607775e-06,
+    1.9546817550212278e-05,
+    7.978229377296505e-05,
+    0.00015667979703731105,
+    0.0002475296377060023,
+    0.0047129763439864025,
+    0.022738490530723673,
+    0.17023255304364004,
+    0.354576821544943,
+    0.8252762630000168,
+    0.8234577261844882,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP30.json
+++ b/params/InP/det_InP30.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    2.8831930484931145e-38,
+    1.3221097976064163e-31,
+    1.0481474149797866e-26,
+    6.253776648180276e-23,
+    6.539265289764179e-20,
+    1.922913082867122e-17,
+    1.02274116109583e-15,
+    2.142538960953108e-15,
+    8.099121757643019e-14,
+    2.076144254609689e-12,
+    3.990122243988634e-11,
+    5.911844814974157e-10,
+    9.416991961713992e-10,
+    6.1705626510658585e-09,
+    4.7014508509031725e-08,
+    3.227820807988964e-07,
+    5.658238099184212e-07,
+    2.418400319742428e-06,
+    1.3102031755667632e-05,
+    2.9424930849715706e-05,
+    5.028333598716505e-05,
+    0.001696716587277603,
+    0.011168463016369364,
+    0.1235640738600088,
+    0.2970015584034164,
+    0.8242955400524957,
+    0.8226496704518621,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP35.json
+++ b/params/InP/det_InP35.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    1.9734336869363575e-44,
+    1.079192228261953e-36,
+    5.4832160973469615e-31,
+    1.3779787538742205e-26,
+    4.554694782083263e-23,
+    3.4290760079241586e-20,
+    3.513618906990975e-18,
+    8.329179799119479e-18,
+    5.750948792614753e-16,
+    2.5214585198040074e-14,
+    7.89465084244747e-13,
+    1.823348359516464e-11,
+    3.135444537859669e-11,
+    2.8155308196696244e-10,
+    3.010227217113016e-09,
+    2.8473688125300883e-08,
+    5.4796445101037884e-08,
+    2.992129072421189e-07,
+    2.151645785154061e-06,
+    5.526089335591672e-06,
+    1.021459046856115e-05,
+    0.000610834209090879,
+    0.005485613303111391,
+    0.08968954571789599,
+    0.24877521691833782,
+    0.8233159825541012,
+    0.8218424076610548,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP40.json
+++ b/params/InP/det_InP40.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    1.3507387300238843e-50,
+    8.809070681191085e-42,
+    2.868457083470902e-35,
+    3.036285996368679e-30,
+    3.172412134801885e-26,
+    6.114973356252122e-23,
+    1.2071009061898509e-20,
+    3.237991812069495e-20,
+    4.083580047931287e-18,
+    3.0622886887440475e-16,
+    1.5619950496016562e-14,
+    5.623624002664091e-13,
+    1.0439652587538882e-12,
+    1.2846824908487423e-11,
+    1.9273769281044942e-10,
+    2.5117593685816246e-09,
+    5.30668795317038e-09,
+    3.7019662596561316e-08,
+    3.5334821889502606e-07,
+    1.0378159765576818e-06,
+    2.0749987325234906e-06,
+    0.0002199061609896509,
+    0.0026943683537446117,
+    0.06510156520248922,
+    0.20837974347832286,
+    0.8223375891198631,
+    0.8210359370339555,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP45.json
+++ b/params/InP/det_InP45.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    9.245282113426035e-57,
+    7.190537907337905e-47,
+    1.5005875919599958e-39,
+    6.690257470098922e-34,
+    2.2096318709713558e-29,
+    1.0904657424117415e-25,
+    4.146985305734814e-23,
+    1.2587783224630838e-22,
+    2.899630410424968e-20,
+    3.7191220635026586e-18,
+    3.0904831431704813e-16,
+    1.7344544589233725e-14,
+    3.475945590251264e-14,
+    5.861804426942776e-13,
+    1.234053629530393e-11,
+    2.2157070407930773e-10,
+    5.139190504128177e-10,
+    4.580201540751994e-09,
+    5.802765708824476e-08,
+    1.9490492024104322e-07,
+    4.215166289070611e-07,
+    7.916832247031449e-05,
+    0.0013233927410710561,
+    0.04725426757255045,
+    0.17454358207371293,
+    0.8213603583664579,
+    0.8202302577932173,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}

--- a/params/InP/det_InP50.json
+++ b/params/InP/det_InP50.json
@@ -1,0 +1,273 @@
+{
+ "pixsize": {
+  "title": "Pixel size (micron).",
+  "val": 10.0
+ },
+ "Npix": {
+  "title": "Number of pixels on a side.",
+  "val": 1968
+ },
+ "readnoise": {
+  "title": "Read out noise (e-).",
+  "val": 15
+ },
+ "Idark": {
+  "title": "Dark current w stray light (e-/sec/pix).",
+  "val": 31.0
+ },
+ "Fullwell": {
+  "title": "Full well (e-).",
+  "val": 150000
+ },
+ "QE": {
+  "title": "Spectral distribution of quantum efficiency (W?? in um; V?? QE value).",
+  "wavelength": {
+   "val": [
+    0.20663,
+    0.21014,
+    0.21376,
+    0.21751,
+    0.22139,
+    0.22541999999999998,
+    0.22959000000000002,
+    0.23392,
+    0.23842,
+    0.2431,
+    0.24796,
+    0.25302,
+    0.25829,
+    0.26379,
+    0.26952,
+    0.27551,
+    0.28176999999999996,
+    0.28833,
+    0.29519,
+    0.30239,
+    0.30995,
+    0.31789999999999996,
+    0.32626,
+    0.33508,
+    0.34439,
+    0.35423000000000004,
+    0.36465,
+    0.3757,
+    0.37970939749120003,
+    0.38744,
+    0.39994,
+    0.41326999999999997,
+    0.42752,
+    0.44279,
+    0.45919,
+    0.4739835734912,
+    0.47685000000000005,
+    0.49592,
+    0.51658,
+    0.53904,
+    0.56355,
+    0.5682577494912,
+    0.59038,
+    0.6199,
+    0.6525299999999999,
+    0.6625319254912,
+    0.68878,
+    0.72929,
+    0.7568061014912001,
+    0.7748700000000001,
+    0.82653,
+    0.8510802774912,
+    0.8855700000000001,
+    0.8982173654912,
+    0.9453544534912,
+    0.95369,
+    1.0331700000000001,
+    1.0396286294912,
+    1.12709,
+    1.1339028054912,
+    1.2281769814912,
+    1.2398,
+    1.3224511574912,
+    1.37756,
+    1.4167253334912,
+    1.5109995094912,
+    1.5487091798911998,
+    1.54975,
+    1.6052736854912,
+    1.7711400000000002,
+    1.8880962134912,
+    2.06633
+   ],
+   "title": "Wavelength in micron."
+  },
+  "qe_value": {
+   "val": [
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    0.0,
+    6.328036611145662e-63,
+    5.86938591686637e-52,
+    7.850084751554571e-44,
+    1.4741544462460292e-37,
+    1.5390412083130397e-32,
+    1.9445964292842158e-28,
+    1.4246934152558472e-25,
+    4.893535737788884e-25,
+    2.0589425010342509e-22,
+    4.5168402881392e-20,
+    6.114671144864859e-18,
+    5.349454850918279e-16,
+    1.1573371474841038e-15,
+    2.674649291516774e-14,
+    7.901352031098833e-13,
+    1.9545493696684546e-11,
+    4.9769798546271226e-11,
+    5.666784806368201e-10,
+    9.529435291001906e-09,
+    3.660372242501908e-08,
+    8.562716962679474e-08,
+    2.8501353734507987e-05,
+    0.0006500107324544281,
+    0.0342997253118703,
+    0.14620164865637336,
+    0.8203842889122052,
+    0.819425369162256,
+    0.8020552699896948,
+    0.8,
+    0.8092773412847226,
+    0.81,
+    0.81,
+    0.8063013142086334,
+    0.78,
+    0.7683088148107919,
+    0.76,
+    0.73,
+    0.71,
+    0.6969355831999335,
+    0.0,
+    0.0,
+    0.0,
+    0.0
+   ],
+   "title": "QE values."
+  }
+ },
+ "spixdim": {
+  "title": "Dimensions of the subpixel grid.",
+  "val": [
+   32,
+   32
+  ]
+ },
+ "Nmargin": {
+  "title": "Number of margin pixels for simpix calculation.",
+  "val": 10
+ },
+ "interpix": {
+  "title": "Parameters of the interpixel flat.",
+  "stddev": {
+   "val": 0.01,
+   "title": "standard deviation of the interpixel flat."
+  }
+ },
+ "intrapix": {
+  "title": "Information about files describing intrapixel pattern.",
+  "file_x": {
+   "val": "pixsim/data/intrapix/intravx.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the x-axis."
+  },
+  "file_y": {
+   "val": "pixsim/data/intrapix/intravy.csv",
+   "title": "Path to the definiton file of the intrapix flat pattern along with the y-axis."
+  }
+ },
+ "persistence": {
+  "title": "Persistence parameters.",
+  "tau": {
+   "val": [
+    1,
+    10,
+    100,
+    1000,
+    10000
+   ],
+   "title": "Detrapping times in second."
+  },
+  "rho": {
+   "val": [
+    0.001,
+    0.0015,
+    0.0015,
+    0.002,
+    0.003
+   ],
+   "title": "Trapping fractions."
+  }
+ },
+ "readparams": {
+  "title": "Parameters related to the reset/read operation.",
+  "fsmpl": {
+   "val": 200000.0,
+   "title": "Sampling frequency in Hz."
+  },
+  "ncol_ch": {
+   "val": 123,
+   "title": "Num. of col. in one ch."
+  },
+  "nrow_ch": {
+   "val": 1968,
+   "title": "Num. of row in one ch."
+  },
+  "npix_pre": {
+   "val": 0,
+   "title": "Npix before reading each row."
+  },
+  "npix_post": {
+   "val": 0,
+   "title": "Npix after reading each row."
+  },
+  "t_overhead": {
+   "val": 0.1,
+   "title": "Overhead time between reset and the 1st read in sec."
+  }
+ },
+ "gain": {
+  "title": "Conversion gain in e/adu.",
+  "val": 3.3
+ },
+ "location": {
+  "title": "Parameters defining the detector location on the telescope focal plane.",
+  "offset_x": {
+   "val": 1.65,
+   "title": "Offset in x direction in mm."
+  },
+  "offset_y": {
+   "val": 1.65,
+   "title": "Offset in y direction in mm."
+  }
+ }
+}


### PR DESCRIPTION
検出器に異なる厚さの InP 層を付加したときの実効的な quantum efficiency を模擬するための `det.json` ファイルを追加しました. ファイル名は以下のフォーマットで付けています.

- det_InP{thickness:02d}.json
  - thickness: thickness of the InP layer in μm